### PR TITLE
Preserve array fields in the stored document

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,9 +217,12 @@ var getIndexEntries = function (doc, batchOptions, indexerOptions) {
     } else {
       fieldOptions.stopwords = batchOptions.stopwords
     }
+
+    // store the field BEFORE mutating.
+    if (fieldOptions.store) docToStore[fieldName] = field
+
     if (Array.isArray(field)) field = field.join(' ') // make filter fields searchable
 
-    if (fieldOptions.store) docToStore[fieldName] = field
 
     var vecOps = {
       separator: fieldOptions.separator || batchOptions.separator,

--- a/test/test.js
+++ b/test/test.js
@@ -132,3 +132,28 @@ test('concurrancy test', function (t) {
     })
   })
 })
+
+test('preserve array fields in stored document', function (t) {
+    t.plan(6)
+    sia({indexPath: 'test/sandbox/preserveArrayFields'}, function (err, indexer) {
+        t.error(err)
+        sis(indexer.options, function (err, searcher) {
+            t.error(err)
+            indexer.add([{'id': '1', 'anArray': ['one', 'two', 'three']}], function (err) {
+                var q = {};
+                if (!err) t.pass('no errors')
+
+                q.query = {
+                    AND: {'*': ['one']}
+                }
+
+                searcher.search(q, function (err, searchResults) {
+                    if (!err) t.pass('no errors')
+
+                    t.equal(searchResults.hits.length, 1)
+                    t.deepEqual(searchResults.hits[0].document, {'id': '1', 'anArray': ['one', 'two', 'three']})
+                })
+            })
+        })
+    })
+})


### PR DESCRIPTION
if the source document has fields that are arrays and those fields are to be stored in the document index, the field value stored in the document index is the joined value of the array used for indexing, rather than the original array value. 

I'd have expected the field values stored in the index to be the same as the field values stored in the original document.

Fixing this is simply a case of swapping the order of a couple of lines of code. I've added a unit test to cover it.