### PR TITLE
set get value to empty array if no value

### DIFF
--- a/lib/delete.js
+++ b/lib/delete.js
@@ -79,8 +79,11 @@ RecalibrateDB.prototype._transform = function (dbEntry, encoding, end) {
   const sep = this.options.keySeparator
   var that = this
   this.options.indexes.get(dbEntry.key, function (err, value) {
-    if (err) that.options.log.info(err)
+    if (err) {
+      that.options.log.info(err)
+    }
     // handle errors better
+    if (!value) value = []
     var docId = dbEntry.value
     var dbInstruction = {}
     dbInstruction.key = dbEntry.key


### PR DESCRIPTION
if `value` is null, the function would previously error out because it tries to call functions of the null `value`

this sets value to an empty array, indicating that no results were found but preventing the errors