### PR TITLE
Make leveldown an optional dependency (no native build)

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ const RecalibrateDB = require('./lib/delete.js').RecalibrateDB
 const bunyan = require('bunyan')
 const del = require('./lib/delete.js')
 const docProc = require('docproc')
-const leveldown = require('leveldown')
 const levelup = require('levelup')
 const pumpify = require('pumpify')
 
@@ -142,6 +141,7 @@ const getOptions = function (options, done) {
     level: options.logLevel
   })
   if (!options.indexes) {
+    const leveldown = require('leveldown')
     levelup(options.indexPath || 'si', {
       valueEncoding: 'json',
       db: leveldown

--- a/package.json
+++ b/package.json
@@ -32,9 +32,11 @@
     "async": "^2.1.4",
     "bunyan": "^1.8.1",
     "docproc": "^0.0.8",
-    "leveldown": "^1.5.0",
     "levelup": "^1.3.3",
     "pumpify": "^1.3.5"
+  },
+  "optionalDependencies": {
+    "leveldown": "^1.5.0"
   },
   "devDependencies": {
     "JSONStream": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "pumpify": "^1.3.5"
   },
   "optionalDependencies": {
-    "leveldown": "^1.5.0"
+    "leveldown": "^1.6.0"
   },
   "devDependencies": {
     "JSONStream": "^1.2.1",


### PR DESCRIPTION
`leveldown` should be an optional dependency so it can be used in projects where native compilation is not possible (when using memdown instead for example).

This change still installs leveldown as usual, but can now be provided with a `--no-optional` flag as well.