### PR TITLE
Allow an `appendOnly: true` option to skip del ops

### DIFF
--- a/lib/add.js
+++ b/lib/add.js
@@ -11,6 +11,8 @@ const emitIndexKeys = function (s) {
   s.deltaIndex = {}
 }
 
+const noop = function (_, cb) { cb() }
+
 const IndexBatch = function (indexer) {
   this.indexer = indexer
   this.deltaIndex = {}
@@ -21,7 +23,8 @@ util.inherits(IndexBatch, Transform)
 IndexBatch.prototype._transform = function (ingestedDoc, encoding, end) {
   const sep = this.indexer.options.keySeparator
   var that = this
-  this.indexer.deleter([ingestedDoc.id], function (err) {
+  const maybedelete = this.indexer.options.appendOnly ? noop : this.indexer.deleter.bind(this.indexer)
+  maybedelete([ingestedDoc.id], function (err) {
     if (err) that.indexer.log.info(err)
     that.indexer.options.log.info('processing doc ' + ingestedDoc.id)
     that.deltaIndex['DOCUMENT' + sep + ingestedDoc.id + sep] = ingestedDoc.stored


### PR DESCRIPTION
This speeds up indexing (a LOT) for users who don't need to delete or modify entries in the index.